### PR TITLE
Pass schema through to read/write functions.

### DIFF
--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -44,6 +44,7 @@ def write_snowflake(
         write_pandas(
             conn=conn,
             df=df,
+            schema=schema,
             # NOTE: since ensure_db_exists uses uppercase for the table name
             table_name=name.upper(),
             parallel=1,
@@ -72,14 +73,18 @@ def ensure_db_exists(
             password=password,
             account=account,
             database=database,
-            schema=schema,
             warehouse=warehouse,
             numpy=True,
         )
     )
     # NOTE: pd_writer will automatically uppercase the table name
     df._meta.to_sql(
-        name=name, con=engine, index=False, if_exists="append", method=pd_writer
+        name=name,
+        schema=schema,
+        con=engine,
+        index=False,
+        if_exists="append",
+        method=pd_writer,
     )
 
 


### PR DESCRIPTION
We need to pass the schema through to the read/write functions if the table is not in the default `public` schema.