### PR TITLE
Update `to_snowflake` API

### DIFF
--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -15,38 +15,41 @@ client = Client(n_workers=2, threads_per_worker=10)
 
 
 @pytest.fixture
-def table(credentials):
+def table(connection_kwargs):
     name = f"test_table_{uuid.uuid4().hex}".upper()
 
     yield name
 
-    engine = create_engine(URL(**credentials))
-    engine.execute(f"DROP TABLE {name}")
+    engine = create_engine(URL(**connection_kwargs))
+    engine.execute(f"DROP TABLE IF EXISTS {name}")
 
 
 @pytest.fixture(scope="module")
-def credentials():
+def connection_kwargs():
     return dict(
         user=os.environ["SNOWFLAKE_USER"],
         password=os.environ["SNOWFLAKE_PASSWORD"],
         account=os.environ["SNOWFLAKE_ACCOUNT"],
         database="testdb",
         schema="public",
-        warehouse="COMPUTE_WH",
+        warehouse=os.environ["SNOWFLAKE_WAREHOUSE"],
     )
 
 
-def test_write_read_roundtrip(table, credentials):
+def test_write_read_roundtrip(table, connection_kwargs):
 
     # TODO: Find out if snowflake supports lower-case column names
-    df = pd.DataFrame({"A": range(100), "B": range(100, 200)})
-    ddf = dd.from_pandas(df, npartitions=50)
+    df = pd.DataFrame({"A": range(10), "B": range(10, 20)})
+    ddf = dd.from_pandas(df, npartitions=2)
 
-    to_snowflake(ddf, name=table, **credentials)
+    to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
+
     query = f"SELECT * FROM {table}"
-    df_out = read_snowflake(query, connection_args=credentials)
+    df_out = read_snowflake(query, connection_kwargs=connection_kwargs)
     # FIXME: Why does read_snowflake return lower-case columns names?
     df_out.columns = df_out.columns.str.upper()
     # FIXME: We need to sort the DataFrame because paritions are written
     # in a non-sequential order.
-    pd.testing.assert_frame_equal(df, df_out.sort_values(by="A").reset_index(drop=True))
+    dd.utils.assert_eq(
+        df, df_out.sort_values(by="A").reset_index(drop=True), check_dtype=False
+    )

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
 dask
 distributed
-snowflake-connector-python[pandas]
+snowflake-connector-python[pandas]>=2.6.0
 snowflake-sqlalchemy


### PR DESCRIPTION
This PR primarily does two things:

1. Updates the `to_snowflake` API to use a `connection_kwargs` dictionary instead of passing individual `user`, `account`, etc. keyword arguments. This makes the `to_snowflake` and `read_snowflake` APIs more consistent with one another.
2. Sets a new minimum version for `snowflake-connector-python>=2.6.0` which includes the new distributed fetch capabilities