### PR TITLE
Remove `use_new_put_get` workaround

### DIFF
--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -24,11 +24,6 @@ def write_snowflake(
     name: str,
     connection_kwargs: Dict,
 ):
-    # TODO: Remove the `use_new_put_get` logic below once the known PUT issue with
-    # `snowflake-connector-python` is resolved
-    if "use_new_put_get" not in connection_kwargs:
-        connection_kwargs["use_new_put_get"] = False
-
     with snowflake.connector.connect(**connection_kwargs) as conn:
         # NOTE: Use a process-wide lock to avoid a `boto` multithreading issue
         # https://github.com/snowflakedb/snowflake-connector-python/issues/156


### PR DESCRIPTION
Nominally the `snowflake-connector-python==2.6.1` release contains a fix which makes this workaround no longer needed. However, locally I'm finding that using `snowflake-connector-python==2.6.0` also works without this workaround (which wasn't the case previously). My guess is the snowflake team added some similar patch in their backend. 