### PR TITLE
Fetch application IDs on cluster

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -39,4 +39,5 @@ jobs:
           SNOWFLAKE_PASSWORD: ${{ secrets.SNOWFLAKE_PASSWORD }}
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
+          SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
         run: pytest dask_snowflake

--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -100,9 +100,7 @@ def to_snowflake(
 
     """
     if "application" not in connection_kwargs:
-        connection_kwargs["application"] = dask.config.get(
-            "snowflake.partner", "dask"
-        )
+        connection_kwargs["application"] = dask.config.get("snowflake.partner", "dask")
     # Write the DataFrame meta to ensure table exists before
     # trying to write all partitions in parallel. Otherwise
     # we run into race conditions around creating a new table.

--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -99,6 +99,10 @@ def to_snowflake(
     ... )
 
     """
+    if "application" not in connection_kwargs:
+        connection_kwargs["application"] = dask.config.get(
+            "snowflake.partner", "dask"
+        )
     # Write the DataFrame meta to ensure table exists before
     # trying to write all partitions in parallel. Otherwise
     # we run into race conditions around creating a new table.

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -80,7 +80,9 @@ def test_application_id_default(table, connection_kwargs, monkeypatch):
     count_after_write = ddf.npartitions + 1
     assert count == count_after_write
 
-    ddf_out = read_snowflake(f"SELECT * FROM {table}", connection_kwargs=connection_kwargs)
+    ddf_out = read_snowflake(
+        f"SELECT * FROM {table}", connection_kwargs=connection_kwargs
+    )
     assert count == count_after_write + ddf_out.npartitions
 
 
@@ -89,6 +91,7 @@ def test_application_id_config(table, connection_kwargs, monkeypatch):
         # Patch Snowflake's normal connection mechanism with checks that
         # the expected application ID is set
         count = 0
+
         def mock_connect(**kwargs):
             nonlocal count
             count += 1
@@ -102,7 +105,9 @@ def test_application_id_config(table, connection_kwargs, monkeypatch):
         count_after_write = ddf.npartitions + 1
         assert count == count_after_write
 
-        ddf_out = read_snowflake(f"SELECT * FROM {table}", connection_kwargs=connection_kwargs)
+        ddf_out = read_snowflake(
+            f"SELECT * FROM {table}", connection_kwargs=connection_kwargs
+        )
         assert count == count_after_write + ddf_out.npartitions
 
 
@@ -114,7 +119,7 @@ def test_application_id_config(table, connection_kwargs, monkeypatch):
 #         client.run(lambda: dask.config.set({"snowflake.partner": "bar"}))
 #         assert dask.config.get("snowflake.partner") == "foo"
 #         assert all(client.run(lambda: dask.config.get("snowflake.partner") == "bar").values())
-    
+
 #         # Patch Snowflake's normal connection mechanism with checks that
 #         # the expected application ID is set
 #         def mock_connect(**kwargs):
@@ -158,5 +163,7 @@ def test_application_id_explicit(table, connection_kwargs, monkeypatch):
     count_after_write = ddf.npartitions + 1
     assert count == count_after_write
 
-    ddf_out = read_snowflake(f"SELECT * FROM {table}", connection_kwargs=connection_kwargs)
+    ddf_out = read_snowflake(
+        f"SELECT * FROM {table}", connection_kwargs=connection_kwargs
+    )
     assert count == count_after_write + ddf_out.npartitions

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -9,7 +9,7 @@ from sqlalchemy import create_engine
 
 import dask
 import dask.dataframe as dd
-from distributed import Client, Lock
+from distributed import Client
 
 from dask_snowflake import read_snowflake, to_snowflake
 


### PR DESCRIPTION
This PR ensure the `snowflake.partner` application ID is set when using `to_snowflake`