### PR TITLE
Operate on Snowflake with already existing connection

### DIFF
--- a/dask_snowflake/__init__.py
+++ b/dask_snowflake/__init__.py
@@ -1,3 +1,3 @@
-from .core import read_snowflake, to_snowflake
+from .core import read_snowflake, read_snowflake_with_conn, to_snowflake
 
 __version__ = "0.1.0"

--- a/dask_snowflake/__init__.py
+++ b/dask_snowflake/__init__.py
@@ -1,3 +1,3 @@
-from .core import read_snowflake, read_snowflake_with_conn, to_snowflake
+from .core import read_snowflake, read_snowflake_with_conn, to_snowflake, write_snowflake, write_snowflake_with_conn
 
 __version__ = "0.1.0"

--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -195,7 +195,7 @@ def read_snowflake_with_conn(
     # Some clusters will overwrite the `snowflake.partner` configuration value.
     # We fetch snowflake batches on the cluster to ensure we capture the
     # right partner application ID.
-    batches = _fetch_query_batches(query, connection).compute()    
+    batches = _fetch_query_batches(query, connection).compute(scheduler='single-threaded')    
 
     if arrow_options is None:
         arrow_options = {}


### PR DESCRIPTION
There are use-cases where operating on Snowflake using an already existing DB connection is necessary. One example is with temporary tables.

When creating a temporary table, the table only exists relative to and as long as the connection used to create it. With the current setup, which establishes a new connection on every dask-snowflake operation, this library will not be able to write to temporary tables. In this case, the original connection must be supplied to the library functions in order to work on the temporary table.

