### PR TITLE
Added lower bound on dask version required for library

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -1,4 +1,4 @@
-dask
+dask>=2021.05.0
 distributed
 snowflake-connector-python[pandas]>=2.6.0
 snowflake-sqlalchemy


### PR DESCRIPTION
Not all versions of dask support this library. Specifically, versions older than 2021.05.0 of dask do not implement `DataFrameIOLayer`. This dask class is required by `dask_snowflake`.

This PR adds this version lower bound to the `requirements.txt` package dependencies.