### PR TITLE
Update `pre-commit` hooks

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,6 +1,6 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 20.8b1
+    rev: 22.3.0
     hooks:
     - id: black
       language_version: python3
@@ -10,12 +10,12 @@ repos:
     hooks:
       - id: blackdoc
 -   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.8.3
+    rev: 3.9.2
     hooks:
     - id: flake8
       language_version: python3
 -   repo: https://github.com/pycqa/isort
-    rev: 5.8.0
+    rev: 5.10.1
     hooks:
     - id: isort
       language_version: python3


### PR DESCRIPTION
Avoids errors like 

```
black....................................................................Failed
- hook id: black
- exit code: 1
Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/reponmziti_r/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/reponmziti_r/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/reponmziti_r/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 6595, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/reponmziti_r/py_env-python3/lib/python3.10/site-packages/click/__init__.py)
```

that we're currently seeing on `main`