### PR TITLE
Use `arrow_options` with computing `meta`

### DIFF
--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -193,7 +193,7 @@ def read_snowflake(
             # This should never since the above check_can_use* calls should
             # raise before if arrow is not properly setup
             raise RuntimeError(f"Received unknown result batch type {type(b)}")
-        meta = b.to_pandas()
+        meta = b.to_pandas(**arrow_options)
         break
 
     if not batches:

--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -20,7 +20,7 @@ from dask.utils import SerializableLock
 
 @delayed
 def write_snowflake(
-    df: dd.DataFrame,
+    df: pd.DataFrame,
     name: str,
     connection_kwargs: Dict,
 ):

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -12,6 +12,7 @@ import dask.dataframe as dd
 from distributed import Client, Lock, worker_client
 
 from dask_snowflake import read_snowflake, to_snowflake
+from dask_snowflake.core import write_snowflake
 
 
 @pytest.fixture
@@ -63,7 +64,7 @@ def test_write_read_roundtrip(table, connection_kwargs, client):
 
 
 def test_arrow_options(table, connection_kwargs, client):
-    to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
+    write_snowflake(df, name=table, connection_kwargs=connection_kwargs).compute()
 
     query = f"SELECT * FROM {table}"
     df_out = read_snowflake(

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -12,7 +12,6 @@ import dask.dataframe as dd
 from distributed import Client, Lock, worker_client
 
 from dask_snowflake import read_snowflake, to_snowflake
-from dask_snowflake.core import write_snowflake
 
 
 @pytest.fixture
@@ -64,7 +63,7 @@ def test_write_read_roundtrip(table, connection_kwargs, client):
 
 
 def test_arrow_options(table, connection_kwargs, client):
-    write_snowflake(df, name=table, connection_kwargs=connection_kwargs).compute()
+    to_snowflake(ddf.repartition(1), name=table, connection_kwargs=connection_kwargs)
 
     query = f"SELECT * FROM {table}"
     df_out = read_snowflake(

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -66,7 +66,9 @@ def test_arrow_options(table, connection_kwargs, client):
     to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
 
     query = f"SELECT * FROM {table}"
-    df_out = read_snowflake(query, connection_kwargs=connection_kwargs, arrow_options={"categories": ["A"]})
+    df_out = read_snowflake(
+        query, connection_kwargs=connection_kwargs, arrow_options={"categories": ["A"]}
+    )
     # FIXME: Why does read_snowflake return lower-case columns names?
     df_out.columns = df_out.columns.str.upper()
     # FIXME: We need to sort the DataFrame because paritions are written

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -63,6 +63,8 @@ def test_write_read_roundtrip(table, connection_kwargs, client):
 
 
 def test_arrow_options(table, connection_kwargs, client):
+    # We use a single partition Dask DataFrame to ensure the
+    # categories used below are always in the same order.
     to_snowflake(ddf.repartition(1), name=table, connection_kwargs=connection_kwargs)
 
     query = f"SELECT * FROM {table}"


### PR DESCRIPTION
On a call with @ncclementi today I noticed we're not using `arrow_options` when computing `meta` but we are when computing partitions. This could lead to `meta` not being correct. This PR makes sure we use `arrow_options` accordingly. 