### PR TITLE
Update `pre-commit` hook versions

### DIFF
--- a/.pre-commit-config.yaml
+++ b/.pre-commit-config.yaml
@@ -1,16 +1,16 @@
 repos:
 -   repo: https://github.com/psf/black
-    rev: 22.3.0
+    rev: 22.10.0
     hooks:
     - id: black
       language_version: python3
       exclude: versioneer.py
 -   repo: https://github.com/keewis/blackdoc
-    rev: v0.3.4
+    rev: v0.3.7
     hooks:
       - id: blackdoc
--   repo: https://gitlab.com/pycqa/flake8
-    rev: 3.9.2
+-   repo: https://github.com/pycqa/flake8
+    rev: 5.0.4
     hooks:
     - id: flake8
       language_version: python3


### PR DESCRIPTION
In addition to being good to do periodically anyways, updating the `black` pre-commit hook should fix some linting errors we're seeing on `main`

```
black....................................................................Failed
- hook id: black
- exit code: 1

Traceback (most recent call last):
  File "/home/runner/.cache/pre-commit/repod4ln0wga/py_env-python3/bin/black", line 8, in <module>
    sys.exit(patched_main())
  File "/home/runner/.cache/pre-commit/repod4ln0wga/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 6606, in patched_main
    patch_click()
  File "/home/runner/.cache/pre-commit/repod4ln0wga/py_env-python3/lib/python3.10/site-packages/black/__init__.py", line 6595, in patch_click
    from click import _unicodefun  # type: ignore
ImportError: cannot import name '_unicodefun' from 'click' (/home/runner/.cache/pre-commit/repod4ln0wga/py_env-python3/lib/python3.10/site-packages/click/__init__.py)
```