### PR TITLE
Result batching

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
-        python-version: ["3.7", "3.8", "3.9"]
+        os: ["ubuntu-latest"]
+        python-version: ["3.9"]
 
     steps:
       - name: Checkout source

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -13,8 +13,8 @@ jobs:
     strategy:
       fail-fast: false
       matrix:
-        os: ["ubuntu-latest"]
-        python-version: ["3.9"]
+        os: ["windows-latest", "ubuntu-latest", "macos-latest"]
+        python-version: ["3.7", "3.8", "3.9"]
 
     steps:
       - name: Checkout source
@@ -42,4 +42,4 @@ jobs:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
           SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
-        run: pytest dask_snowflake/tests/test_core.py::test_result_batching -s
+        run: pytest dask_snowflake

--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -42,4 +42,4 @@ jobs:
           SNOWFLAKE_ACCOUNT: ${{ secrets.SNOWFLAKE_ACCOUNT }}
           SNOWFLAKE_WAREHOUSE: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
           SNOWFLAKE_ROLE: ${{ secrets.SNOWFLAKE_ROLE }}
-        run: pytest dask_snowflake
+        run: pytest dask_snowflake/tests/test_core.py::test_result_batching -s

--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -121,7 +121,6 @@ def to_snowflake(
 
 
 def _fetch_batches(chunks: list[ArrowResultBatch], arrow_options: dict):
-    print(chunks)
     return pd.concat([chunk.to_pandas(**arrow_options) for chunk in chunks], axis=0)
 
 
@@ -173,7 +172,6 @@ def _partition_batches(
         )
         approx_row_size = meta.memory_usage().sum() / len(meta)
         target = max(partition_bytes / approx_row_size, 1)
-        print(approx_row_size, target)
 
     else:
         assert False  # unreachable
@@ -259,7 +257,6 @@ def read_snowflake(
             # This should never since the above check_can_use* calls should
             # raise before if arrow is not properly setup
             raise RuntimeError(f"Received unknown result batch type {type(b)}")
-        print(b.rowcount)
         if b.rowcount > 0:
             meta = b.to_pandas(**arrow_options)
             break
@@ -275,9 +272,6 @@ def read_snowflake(
         batches_partitioned = _partition_batches(
             batches, meta, npartitions=npartitions, partition_size=partition_size
         )
-        for b in batches:
-            print(b.rowcount)
-        print(batches_partitioned)
 
         # Create Blockwise layer
         layer = DataFrameIOLayer(

--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -205,6 +205,9 @@ def read_snowflake(
         meta = b.to_pandas(**arrow_options)
         break
 
+    if not meta:
+        raise RuntimeError("Unable to infer meta from single batch")
+
     if not batches:
         # empty dataframe - just use meta
         graph = {(output_name, 0): meta}
@@ -221,4 +224,9 @@ def read_snowflake(
         )
         divisions = tuple([None] * (len(batches) + 1))
         graph = HighLevelGraph({output_name: layer}, {output_name: set()})
+
+        print(f"{batches=}")
+        print(
+            f"{b=}, {b.rowcount=}, {b.compressed_size=}, {b.uncompressed_size=}, {meta.memory_usage(deep=True)}"
+        )
     return new_dd_object(graph, output_name, meta, divisions)

--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -205,7 +205,7 @@ def read_snowflake(
         meta = b.to_pandas(**arrow_options)
         break
 
-    if not meta:
+    if meta is None:
         raise RuntimeError("Unable to infer meta from single batch")
 
     if not batches:

--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -217,6 +217,16 @@ def read_snowflake(
     execute_params:
         Optional query parameters to pass to Snowflake's ``Cursor.execute(...)``
         method.
+    npartitions:
+        An integer number of partitions for the target Dask DataFrame. You
+        must provide either this or ``partition_size``. Partitioning is approximate,
+        and your actual number of partitions may vary.
+    partition_size: int or str
+        Approximate size of each partition in the target Dask DataFrame. Either
+        an integer number of bytes, or a string description like "100 MiB".
+        Reasonable values are often around few hundred MiB per partition. You
+        must provide either this or ``npartitions``. Partitioning is approximate,
+        and your actual partition sizes may vary.
 
     Examples
     --------

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -37,8 +37,8 @@ def connection_kwargs():
         user=os.environ["SNOWFLAKE_USER"],
         password=os.environ["SNOWFLAKE_PASSWORD"],
         account=os.environ["SNOWFLAKE_ACCOUNT"],
-        database="TESTDB",
-        schema="TESTSCHEMA",
+        database="testdb",
+        schema="public",
         warehouse=os.environ["SNOWFLAKE_WAREHOUSE"],
         role=os.environ["SNOWFLAKE_ROLE"],
     )

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -53,7 +53,7 @@ def test_write_read_roundtrip(table, connection_kwargs, client):
     to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
 
     query = f"SELECT * FROM {table}"
-    df_out = read_snowflake(query, connection_kwargs=connection_kwargs)
+    df_out = read_snowflake(query, connection_kwargs=connection_kwargs, npartitions=2)
     # FIXME: Why does read_snowflake return lower-case columns names?
     df_out.columns = df_out.columns.str.upper()
     # FIXME: We need to sort the DataFrame because paritions are written
@@ -70,7 +70,10 @@ def test_arrow_options(table, connection_kwargs, client):
 
     query = f"SELECT * FROM {table}"
     df_out = read_snowflake(
-        query, connection_kwargs=connection_kwargs, arrow_options={"categories": ["A"]}
+        query,
+        connection_kwargs=connection_kwargs,
+        arrow_options={"categories": ["A"]},
+        npartitions=2,
     )
     # FIXME: Why does read_snowflake return lower-case columns names?
     df_out.columns = df_out.columns.str.upper()

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -9,6 +9,7 @@ from sqlalchemy import create_engine
 
 import dask
 import dask.dataframe as dd
+import dask.datasets
 from distributed import Client, Lock, worker_client
 
 from dask_snowflake import read_snowflake, to_snowflake
@@ -213,4 +214,12 @@ def test_execute_params(table, connection_kwargs, client):
         df_out,
         check_dtype=False,
         check_index=False,
+    )
+
+
+def test_result_batching(table, connection_kwargs, client):
+    ddf = dask.datasets.timeseries()
+    to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
+    ddf_out = read_snowflake(
+        f"SELECT * FROM {table}", connection_kwargs=connection_kwargs
     )

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -247,7 +247,7 @@ def test_result_batching(table, connection_kwargs, client):
         connection_kwargs=connection_kwargs,
         npartitions=4,
     )
-    assert abs(ddf_out.npartitions - 4) < 2
+    assert abs(ddf_out.npartitions - 4) <= 2
 
     # Can't specify both
     with pytest.raises(ValueError, match="exactly one"):

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -219,7 +219,9 @@ def test_execute_params(table, connection_kwargs, client):
 
 
 @pytest.mark.parametrize(
-    "partitioning", [{"partition_size": "2 MiB"}, {"npartitions": 3}]
+    "partitioning",
+    [{"partition_size": "2 MiB"}, {"npartitions": 3}],
+    ids=["partition_size", "npartitions"],
 )
 def test_result_batching(partitioning, table, connection_kwargs, client):
     ddf = (
@@ -236,5 +238,7 @@ def test_result_batching(partitioning, table, connection_kwargs, client):
         **partitioning,
     )
 
+    # Relatively loose check since we don't control batch sizes and the
+    # dask-snowflake batching algo is approximate.
     assert ddf_out.npartitions < 5 and ddf_out.npartitions > 1
     dd.utils.assert_eq(ddf, ddf_out, check_dtype=False, check_index=False)

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -38,8 +38,8 @@ def connection_kwargs():
         user=os.environ["SNOWFLAKE_USER"],
         password=os.environ["SNOWFLAKE_PASSWORD"],
         account=os.environ["SNOWFLAKE_ACCOUNT"],
-        database="TESTDB",
-        schema="TESTSCHEMA",
+        database="testdb",
+        schema="public",
         warehouse=os.environ["SNOWFLAKE_WAREHOUSE"],
         role=os.environ["SNOWFLAKE_ROLE"],
     )

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -37,8 +37,8 @@ def connection_kwargs():
         user=os.environ["SNOWFLAKE_USER"],
         password=os.environ["SNOWFLAKE_PASSWORD"],
         account=os.environ["SNOWFLAKE_ACCOUNT"],
-        database="testdb",
-        schema="public",
+        database="TESTDB",
+        schema="TESTSCHEMA",
         warehouse=os.environ["SNOWFLAKE_WAREHOUSE"],
         role=os.environ["SNOWFLAKE_ROLE"],
     )
@@ -243,5 +243,5 @@ def test_result_batching(partitioning, table, connection_kwargs, client):
 
     # Relatively loose check since we don't control batch sizes and the
     # dask-snowflake batching algo is approximate.
-    assert ddf_out.npartitions < 5 and ddf_out.npartitions > 1
+    assert ddf_out.npartitions < 6 and ddf_out.npartitions > 1
     dd.utils.assert_eq(ddf, ddf_out, check_dtype=False, check_index=False)


### PR DESCRIPTION
Fixes #7. This is ready for some eyes.

There is an API-design question in particular that I'd like to call out. I've chosen to model the new keyword arguments around those of `DataFrame.repartition`, so the user has to provide *exactly one* of `npartitions` or `partition_size`. This requires some thought from the user of `read_snowflake`, as I have not provided defaults here. Other options here could be
1. Provide a default like `partition_size=100 MiB` or similar so the user doesn't have to specify, but might be the wrong choice in some circumstances. This is also and is different behavior from `DataFrame.repartition`.
2. ~~Fall back on the snowflake-provided result batches, so one batch -> one partition. I don't really like that, as we don't control their batching, and they are typically much smaller than we want, so it would wind up being a poor default in most circumstances.~~

Update: went with option 1