### PR TITLE
Temporarily disable `log_telemetry_imported_packages`

### DIFF
--- a/dask_snowflake/core.py
+++ b/dask_snowflake/core.py
@@ -266,6 +266,17 @@ def read_snowflake(
         arrow_options,
     )
 
+    # Disable `log_imported_packages_in_telemetry` as a temporary workaround for
+    # https://github.com/snowflakedb/snowflake-connector-python/issues/1648.
+    # Also xref https://github.com/coiled/dask-snowflake/issues/51.
+    if connection_kwargs.get("log_imported_packages_in_telemetry"):
+        raise ValueError(
+            "Using `log_imported_packages_in_telemetry=True` when creating a "
+            "Snowflake connection is not currently supported."
+        )
+    else:
+        connection_kwargs["log_imported_packages_in_telemetry"] = False
+
     # Some clusters will overwrite the `snowflake.partner` configuration value.
     # We fetch snowflake batches on the cluster to ensure we capture the
     # right partner application ID.


### PR DESCRIPTION
It so happens we can just disable the non-thread safe functionality in the Snowflake connector highlighted in https://github.com/coiled/dask-snowflake/issues/51. 

I think turning it off by default (with a meaningful error message when a users explicit wants it on) as a temporary workaround for https://github.com/snowflakedb/snowflake-connector-python/issues/1648 makes sense. 

@fjetter do you have bandwidth to review? 