### PR TITLE
Use ``auto_create_table`` when writing

### DIFF
--- a/ci/environment-3.10.yaml
+++ b/ci/environment-3.10.yaml
@@ -6,13 +6,9 @@ dependencies:
   - python=3.10
   - dask
   - distributed
-  # `pandas=2.2` dropped support for `sqlalchemy<2`, but `snowflake-sqlalchemy`
-  # doesn't support `sqlalchemy>=2` yet. Temporarily pinning `pandas<2.2` for now.
-  # xref https://github.com/pandas-dev/pandas/issues/57049
-  # xref https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380
-  - pandas<2.2
+  - pandas
   - pyarrow
-  - snowflake-connector-python >=2.6.0
+  - snowflake-connector-python >=2.7.3
   - snowflake-sqlalchemy
   # Testing
   - pytest

--- a/ci/environment-3.11.yaml
+++ b/ci/environment-3.11.yaml
@@ -6,13 +6,9 @@ dependencies:
   - python=3.11
   - dask
   - distributed
-  # `pandas=2.2` dropped support for `sqlalchemy<2`, but `snowflake-sqlalchemy`
-  # doesn't support `sqlalchemy>=2` yet. Temporarily pinning `pandas<2.2` for now.
-  # xref https://github.com/pandas-dev/pandas/issues/57049
-  # xref https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380
-  - pandas<2.2
+  - pandas
   - pyarrow
-  - snowflake-connector-python >=2.6.0
+  - snowflake-connector-python >=2.7.3
   - snowflake-sqlalchemy
   # Testing
   - pytest

--- a/ci/environment-3.7.yaml
+++ b/ci/environment-3.7.yaml
@@ -6,13 +6,9 @@ dependencies:
   - python=3.7
   - dask
   - distributed
-  # `pandas=2.2` dropped support for `sqlalchemy<2`, but `snowflake-sqlalchemy`
-  # doesn't support `sqlalchemy>=2` yet. Temporarily pinning `pandas<2.2` for now.
-  # xref https://github.com/pandas-dev/pandas/issues/57049
-  # xref https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380
-  - pandas<2.2
+  - pandas
   - pyarrow
-  - snowflake-connector-python >=2.6.0
+  - snowflake-connector-python >=2.7.3
   - snowflake-sqlalchemy
   # Testing
   - pytest

--- a/ci/environment-3.8.yaml
+++ b/ci/environment-3.8.yaml
@@ -6,13 +6,9 @@ dependencies:
   - python=3.8
   - dask
   - distributed
-  # `pandas=2.2` dropped support for `sqlalchemy<2`, but `snowflake-sqlalchemy`
-  # doesn't support `sqlalchemy>=2` yet. Temporarily pinning `pandas<2.2` for now.
-  # xref https://github.com/pandas-dev/pandas/issues/57049
-  # xref https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380
-  - pandas<2.2
+  - pandas
   - pyarrow
-  - snowflake-connector-python >=2.6.0
+  - snowflake-connector-python >=2.7.3
   - snowflake-sqlalchemy
   # Testing
   - pytest

--- a/ci/environment-3.9.yaml
+++ b/ci/environment-3.9.yaml
@@ -6,13 +6,9 @@ dependencies:
   - python=3.9
   - dask
   - distributed
-  # `pandas=2.2` dropped support for `sqlalchemy<2`, but `snowflake-sqlalchemy`
-  # doesn't support `sqlalchemy>=2` yet. Temporarily pinning `pandas<2.2` for now.
-  # xref https://github.com/pandas-dev/pandas/issues/57049
-  # xref https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380
-  - pandas<2.2
+  - pandas
   - pyarrow
-  - snowflake-connector-python >=2.6.0
+  - snowflake-connector-python >=2.7.3
   - snowflake-sqlalchemy
   # Testing
   - pytest

--- a/dask_snowflake/tests/test_core.py
+++ b/dask_snowflake/tests/test_core.py
@@ -159,8 +159,8 @@ def test_application_id_default(table, connection_kwargs, monkeypatch):
     monkeypatch.setattr(snowflake.connector, "connect", mock_connect)
 
     to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
-    # One extra connection is made to ensure the DB table exists
-    count_after_write = ddf.npartitions + 1
+    # One connection is made for writing each partition
+    count_after_write = ddf.npartitions
     assert count == count_after_write
 
     ddf_out = read_snowflake(
@@ -184,8 +184,8 @@ def test_application_id_config(table, connection_kwargs, monkeypatch):
         monkeypatch.setattr(snowflake.connector, "connect", mock_connect)
 
         to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
-        # One extra connection is made to ensure the DB table exists
-        count_after_write = ddf.npartitions + 1
+        # One connection is made for writing each partition
+        count_after_write = ddf.npartitions
         assert count == count_after_write
 
         ddf_out = read_snowflake(
@@ -221,8 +221,8 @@ def test_application_id_config_on_cluster(table, connection_kwargs, client):
         client.run(patch_snowflake_connect)
 
         to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
-        # One extra connection is made to ensure the DB table exists
-        count_after_write = ddf.npartitions + 1
+        # One connection is made for writing each partition
+        count_after_write = ddf.npartitions
 
         ddf_out = read_snowflake(
             f"SELECT * FROM {table}", connection_kwargs=connection_kwargs, npartitions=2
@@ -250,8 +250,8 @@ def test_application_id_explicit(table, connection_kwargs, monkeypatch):
     monkeypatch.setattr(snowflake.connector, "connect", mock_connect)
 
     to_snowflake(ddf, name=table, connection_kwargs=connection_kwargs)
-    # One extra connection is made to ensure the DB table exists
-    count_after_write = ddf.npartitions + 1
+    # One connection is made for writing each partition
+    count_after_write = ddf.npartitions
     assert count == count_after_write
 
     ddf_out = read_snowflake(

--- a/requirements.txt
+++ b/requirements.txt
@@ -1,9 +1,3 @@
 dask>=2021.05.0
 distributed
-snowflake-connector-python[pandas]>=2.6.0
-snowflake-sqlalchemy
-# `pandas=2.2` dropped support for `sqlalchemy<2`, but `snowflake-sqlalchemy`
-# doesn't support `sqlalchemy>=2` yet. Temporarily pinning `pandas<2.2` for now.
-# xref https://github.com/pandas-dev/pandas/issues/57049
-# xref https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380
-pandas<2.2
+snowflake-connector-python[pandas]>=2.7.3


### PR DESCRIPTION
In https://github.com/coiled/dask-snowflake/pull/56 we added a `pandas<2.2` restriction due to `pandas=2.2` only supporting `sqlalchemy>=2`, but `snowflake-sqlalchemy` requiring `sqlalchemy<2`. This is unfortunate, but better than things breaking with the latest `pandas` release. 

I noticed that we're only using `snowflake-sqlalchemy` to auto-create a table if it doesn't exist and `snowflake-connector-python >= 2.7.3` has a `auto_create_table=` keyword for this exact functionality. This PR uses the built in `auto_create_table=True` in snowflake and removes our dependency on `snowflake-sqlalchemy` altogether. This also let's us drop the `pandas<2.2` restriction. 
