### PR TITLE
Remove restrictions on `pandas` version

### DIFF
--- a/requirements.txt
+++ b/requirements.txt
@@ -2,8 +2,3 @@ dask>=2024.3.0
 distributed
 snowflake-connector-python[pandas]>=2.6.0
 snowflake-sqlalchemy
-# `pandas=2.2` dropped support for `sqlalchemy<2`, but `snowflake-sqlalchemy`
-# doesn't support `sqlalchemy>=2` yet. Temporarily pinning `pandas<2.2` for now.
-# xref https://github.com/pandas-dev/pandas/issues/57049
-# xref https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380
-pandas<2.2


### PR DESCRIPTION
According to https://github.com/snowflakedb/snowflake-sqlalchemy/issues/380, `sqlalchemy>=2` is supported with `snowflake-sqlalchemy==1.6.1`