### PR TITLE
Remove dependency on `pkg_resources`

### DIFF
--- a/dask_snowflake/__init__.py
+++ b/dask_snowflake/__init__.py
@@ -1,8 +1,8 @@
-from pkg_resources import DistributionNotFound, get_distribution
+from importlib.metadata import PackageNotFoundError, version
 
 from .core import read_snowflake, to_snowflake
 
 try:
-    __version__ = get_distribution(__name__).version
-except DistributionNotFound:
-    pass
+    __version__ = version(__name__)
+except PackageNotFoundError:
+    __version__ = "unknown"


### PR DESCRIPTION
`pkg_resources` is deprecated in python 3.13

See https://setuptools.pypa.io/en/latest/pkg_resources.html

> Use of pkg_resources is deprecated in favor of [importlib.resources](https://docs.python.org/3.11/library/importlib.resources.html#module-importlib.resources), [importlib.metadata](https://docs.python.org/3.11/library/importlib.metadata.html#module-importlib.metadata) and their backports ([importlib_resources](https://pypi.org/project/importlib_resources), [importlib_metadata](https://pypi.org/project/importlib_metadata)). Some useful APIs are also provided by [packaging](https://pypi.org/project/packaging) (e.g. requirements and version parsing). Users should refrain from new usage of pkg_resources and should work to port to importlib-based solutions.
